### PR TITLE
support printing arrays via simple tokens

### DIFF
--- a/src/EventRegistration.php
+++ b/src/EventRegistration.php
@@ -192,7 +192,7 @@ class EventRegistration
                     }
                 }
 
-                $tokens['reg_'.$key] = $value;
+                $tokens['reg_'.$key] = \is_array($value) ? implode(', ', $value) : $value;
             }
 
             $tokens['reg_confirm_url'] = $this->createStatusUpdateUrl($event, $registration, EventRegistrationConfirmController::ACTION);


### PR DESCRIPTION
Before this commit, if having a checkbox array, only "Array" was printed in the notification mail if using ##reg_field##

Print it as a comma-separated list instead.