### PR TITLE
Prevent sending multiple emails after cancellation

### DIFF
--- a/src/Controller/FrontendModule/EventRegistrationCancelController.php
+++ b/src/Controller/FrontendModule/EventRegistrationCancelController.php
@@ -69,6 +69,7 @@ class EventRegistrationCancelController extends AbstractFrontendModuleController
                 throw new PageNotFoundException('No registration found.');
             }
 
+            $registration->previousCancelationState = $registration->cancelled;
             $registrations[] = $registration;
             $event = CalendarEventsModel::findById((int) $registration->pid);
             $template->event = $event;
@@ -90,7 +91,7 @@ class EventRegistrationCancelController extends AbstractFrontendModuleController
         };
 
         // Send notification
-        if ($model->nc_notification) {
+        if ($model->nc_notification && $registration->previousCancelationState === false) {
             $this->notificationCenter->sendNotification($model->nc_notification, $tokens);
         }
 


### PR DESCRIPTION
If the user clicks multiple times on the cancellation link ,in his double opt-in email, the user receives a cancellation email for each click on the link.

My suggestion is to check the previous state of the cancellation and only send an e-mail if the cancellation was false.