### PR TITLE
Fix: load translations during export

### DIFF
--- a/src/Controller/EventRegistrationExportController.php
+++ b/src/Controller/EventRegistrationExportController.php
@@ -47,6 +47,8 @@ class EventRegistrationExportController extends AbstractBackendController implem
         /** @var AttributeBagInterface $backendSession */
         $backendSession = $request->getSession()->getBag('contao_backend');
 
+        System::loadLanguageFile('default');
+
         // Get the form
         $form = $this->buildForm($request, $backendSession);
 


### PR DESCRIPTION
Fix: load translations during export so exported labels are localized - see: https://github.com/inspiredminds/contao-backend-forms/issues/2